### PR TITLE
feat: 응담 json 파싱 fetcher 구현

### DIFF
--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BinancePriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BinancePriceFetcher.java
@@ -1,4 +1,47 @@
 package dev.asset_tracker_server.fetcher;
 
-public class BinancePriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class BinancePriceFetcher implements PriceFetcher {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "binance".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String url = "https://api.binance.com/api/v3/ticker/price?symbol=" + symbol;
+
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(response);
+
+            BigDecimal price = new BigDecimal(json.get("price").asText());
+
+            return new TickerPriceDto(
+                    symbol,                 // ex: BTCUSDT
+                    "binance",
+                    price,
+                    "USDT",                 // Binance 기준 통화
+                    Instant.now()
+            );
+
+        } catch (Exception e) {
+            throw new RuntimeException("Binance 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BithumbPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BithumbPriceFetcher.java
@@ -1,4 +1,45 @@
 package dev.asset_tracker_server.fetcher;
 
-public class BithumbPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+public class BithumbPriceFetcher implements PriceFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "bithumb".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        // symbol: BTC, ETH 등
+        String url = "https://api.bithumb.com/public/ticker/" + symbol + "_KRW";
+
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode data = root.get("data");
+            BigDecimal price = new BigDecimal(data.get("closing_price").asText());
+
+            return new TickerPriceDto(
+                    symbol + "/KRW",
+                    "bithumb",
+                    price,
+                    "KRW",
+                    Instant.now()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Bithumb 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BybitPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/BybitPriceFetcher.java
@@ -1,4 +1,43 @@
 package dev.asset_tracker_server.fetcher;
 
-public class BybitPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+public class BybitPriceFetcher implements PriceFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "bybit".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String url = "https://api.bybit.com/v5/market/tickers?category=spot&symbol=" + symbol;
+        try {
+            String resp = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(resp);
+            JsonNode item = json.get("result").get("list").get(0);
+            BigDecimal price = new BigDecimal(item.get("lastPrice").asText());
+
+            return new TickerPriceDto(
+                    symbol,
+                    "bybit",
+                    price,
+                    "USDT",
+                    Instant.now()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Bybit 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/FinnhubPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/FinnhubPriceFetcher.java
@@ -1,4 +1,49 @@
 package dev.asset_tracker_server.fetcher;
 
-public class FinnhubPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class FinnhubPriceFetcher implements PriceFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final FinnhubProperties finnhubProperties;
+
+    @Override
+    public boolean supports(String exchange) {
+        return "finnhub".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String token = finnhubProperties.getToken();
+        String url = "https://finnhub.io/api/v1/quote?symbol=" + symbol + "&token=" + token;
+
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(response);
+
+            BigDecimal price = new BigDecimal(json.get("c").asText());
+
+            return new TickerPriceDto(
+                    symbol,
+                    "finnhub",
+                    price,
+                    "USD",
+                    Instant.now() // 또는 Instant.ofEpochSecond(json.get("t").asLong())
+            );
+
+        } catch (Exception e) {
+            throw new RuntimeException("Finnhub 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/FinnhubProperties.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/FinnhubProperties.java
@@ -1,4 +1,18 @@
 package dev.asset_tracker_server.fetcher;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "finnhub")
 public class FinnhubProperties {
+    private String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/GateioPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/GateioPriceFetcher.java
@@ -1,4 +1,42 @@
 package dev.asset_tracker_server.fetcher;
 
-public class GateioPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+public class GateioPriceFetcher implements PriceFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "gateio".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String url = "https://api.gateio.ws/api/v4/spot/tickers?currency_pair=" + symbol;
+        try {
+            String resp = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(resp).get(0);
+            BigDecimal price = new BigDecimal(json.get("last").asText());
+
+            return new TickerPriceDto(
+                    symbol,
+                    "gateio",
+                    price,
+                    "USDT",
+                    Instant.now()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Gate.io 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/OkxPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/OkxPriceFetcher.java
@@ -1,4 +1,43 @@
 package dev.asset_tracker_server.fetcher;
 
-public class OkxPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+public class OkxPriceFetcher implements PriceFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "okx".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String url = "https://www.okx.com/api/v5/market/ticker?instId=" + symbol;
+        try {
+            String resp = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(resp);
+            JsonNode item = json.get("data").get(0);
+            BigDecimal price = new BigDecimal(item.get("last").asText());
+
+            return new TickerPriceDto(
+                    symbol,
+                    "okx",
+                    price,
+                    "USDT",
+                    Instant.now()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("OKX 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetchManager.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetchManager.java
@@ -1,4 +1,29 @@
 package dev.asset_tracker_server.fetcher;
 
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
 public class PriceFetchManager {
+
+    private final List<PriceFetcher> fetchers;
+
+    /**
+     * 주어진 거래소에 맞는 fetcher를 찾아서 가격 조회
+     *
+     * @param exchange 거래소 이름 (예: binance, upbit, finnhub 등)
+     * @param symbol API에 전달할 심볼
+     * @return 가격 정보 DTO
+     */
+    public TickerPriceDto fetch(String exchange, String symbol) {
+        return fetchers.stream()
+                .filter(f -> f.supports(exchange))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 거래소: " + exchange))
+                .fetchPrice(symbol);
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetchScheduler.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetchScheduler.java
@@ -1,4 +1,44 @@
 package dev.asset_tracker_server.fetcher;
 
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import dev.asset_tracker_server.entity.SymbolMapping;
+import dev.asset_tracker_server.repository.SymbolMappingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class PriceFetchScheduler {
+
+    private final SymbolMappingRepository symbolMappingRepository;
+    private final PriceFetchManager priceFetchManager;
+
+    @Scheduled(fixedRate = 60_000)
+    public void fetchAllPrices() {
+        List<SymbolMapping> symbols = symbolMappingRepository.findByIsActiveTrue();
+
+        for (SymbolMapping mapping : symbols) {
+            try {
+                TickerPriceDto dto = priceFetchManager.fetch(mapping.getExchange().name(), mapping.getSymbol());
+                log.info("[{}] {} = {} {} @ {}",
+                        mapping.getExchange(),
+                        mapping.getSymbol(),
+                        dto.price(),
+                        dto.currency(),
+                        dto.timestamp()
+                );
+
+                // 👉 다음 단계에서 저장 처리 예정
+                // assetSnapshotService.save(dto);
+
+            } catch (Exception e) {
+                log.warn("가격 조회 실패: {} - {} ({})", mapping.getExchange(), mapping.getSymbol(), e.getMessage());
+            }
+        }
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/PriceFetcher.java
@@ -1,4 +1,20 @@
 package dev.asset_tracker_server.fetcher;
 
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+
 public interface PriceFetcher {
+
+    /**
+     * 이 fetcher가 해당 거래소(ex: binance, upbit)를 지원하는지 여부를 반환합니다.
+     */
+    boolean supports(String exchange);
+
+    /**
+     * 주어진 심볼에 대한 가격을 조회합니다.
+     * 예: "BTCUSDT", "KRW-BTC", "TSLA"
+     *
+     * @param symbol API에 사용할 심볼
+     * @return 현재 가격 정보 DTO
+     */
+    TickerPriceDto fetchPrice(String symbol);
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/UpbitPriceFetcher.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/fetcher/UpbitPriceFetcher.java
@@ -1,4 +1,47 @@
 package dev.asset_tracker_server.fetcher;
 
-public class UpbitPriceFetcher {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class UpbitPriceFetcher implements PriceFetcher {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public boolean supports(String exchange) {
+        return "upbit".equalsIgnoreCase(exchange);
+    }
+
+    @Override
+    public TickerPriceDto fetchPrice(String symbol) {
+        String url = "https://api.upbit.com/v1/ticker?markets=" + symbol;
+
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode json = objectMapper.readTree(response).get(0); // Upbit은 배열로 응답함
+
+            BigDecimal price = new BigDecimal(json.get("trade_price").asText());
+
+            return new TickerPriceDto(
+                    symbol,                 // ex: KRW-BTC
+                    "upbit",                // exchange
+                    price,                  // 실시간 가격
+                    "KRW",                  // Upbit은 항상 KRW 기준
+                    Instant.now()          // 수집 시점
+            );
+
+        } catch (Exception e) {
+            throw new RuntimeException("Upbit 가격 조회 실패 (" + symbol + "): " + e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
## PR 요약
fetcher 구현

---

## 변경 사항
- Upbit, Bithumb, Binance, Bybit, OKX, Gate.io, Finnhub API 요청 json 파싱 코드 구현

### 수집되는 정보
- 자산 심볼
- 거래소
- 자산 실시간 가격
- 자산 이름
- 수집 시점 시각