### PR TITLE
feat: 유저 포트폴리오의 자산 총합 계산 구현

### DIFF
--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/AssetDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/AssetDto.java
@@ -1,0 +1,14 @@
+package dev.asset_tracker_server.api.dto;
+
+import dev.asset_tracker_server.entity.AssetType;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record AssetDto(
+        String symbol,
+        BigDecimal quantity,
+        AssetType assetType,
+        boolean isKimchi
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/DailyAssetReportDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/DailyAssetReportDto.java
@@ -1,0 +1,10 @@
+package dev.asset_tracker_server.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record DailyAssetReportDto(
+        LocalDate date,
+        BigDecimal totalKrw,
+        BigDecimal totalUsd
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioValuationDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioValuationDto.java
@@ -1,0 +1,17 @@
+package dev.asset_tracker_server.api.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+public class PortfolioValuationDto {
+    private UUID userId;
+    private BigDecimal totalValueUsd;
+    private BigDecimal totalValueKrw;
+    private Instant asOf;
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotHistoryDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotHistoryDto.java
@@ -1,0 +1,10 @@
+package dev.asset_tracker_server.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SnapshotHistoryDto(
+        BigDecimal totalValueUsd,
+        BigDecimal totalValueKrw,
+        LocalDate snapshotDate
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotSummaryDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotSummaryDto.java
@@ -1,0 +1,14 @@
+package dev.asset_tracker_server.api.dto;
+
+import dev.asset_tracker_server.entity.AssetType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SnapshotSummaryDto(
+        String symbol,
+        AssetType assetType,
+        BigDecimal totalValueUsd,
+        BigDecimal totalValueKrw,
+        LocalDate snapshotDate
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetController.java
@@ -1,0 +1,37 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.entity.Asset;
+import dev.asset_tracker_server.service.AssetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/assets")
+public class AssetController {
+
+    private final AssetService assetService;
+
+    @GetMapping("/{userId}")
+    public List<AssetService.AssetDto> getAssets(@PathVariable UUID userId) {
+        return assetService.getAssetsByUser(userId);
+    }
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> registerAsset(
+            @PathVariable UUID userId,
+            @RequestBody Asset asset
+    ) {
+        assetService.saveAsset(userId, asset);
+        return ResponseEntity.ok("자산 등록 완료");
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetValuationController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetValuationController.java
@@ -1,0 +1,24 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.PortfolioValuationDto;
+import dev.asset_tracker_server.service.AssetValuationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/valuation")
+public class AssetValuationController {
+
+    private final AssetValuationService assetValuationService;
+
+    @GetMapping("/{userId}")
+    public PortfolioValuationDto getValuation(@PathVariable UUID userId) {
+        return assetValuationService.getPortfolioSummary(userId);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/PriceHistoryController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/PriceHistoryController.java
@@ -1,0 +1,28 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.entity.AssetPriceHistory;
+import dev.asset_tracker_server.service.AssetPriceHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/history")
+@RequiredArgsConstructor
+public class PriceHistoryController {
+
+    private final AssetPriceHistoryService historyService;
+
+    @GetMapping("/{symbol}")
+    public List<AssetPriceHistory> getPriceHistory(
+            @PathVariable String symbol,
+            @RequestParam(defaultValue = "30") int limit
+    ) {
+        return historyService.getRecentHistory(symbol, limit);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/ReportController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/ReportController.java
@@ -1,0 +1,24 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.DailyAssetReportDto;
+import dev.asset_tracker_server.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("/daily")
+    public List<DailyAssetReportDto> getDailyReport(@RequestParam(defaultValue = "30") int days) {
+        return reportService.getDailyReport(days);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/SnapshotController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/SnapshotController.java
@@ -1,0 +1,34 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.SnapshotHistoryDto;
+import dev.asset_tracker_server.api.dto.SnapshotSummaryDto;
+import dev.asset_tracker_server.service.AssetSnapshotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/snapshot")
+@RequiredArgsConstructor
+public class SnapshotController {
+
+    private final AssetSnapshotService assetSnapshotService;
+
+    @GetMapping("/{userId}/latest")
+    public List<SnapshotSummaryDto> getLatestSnapshots(@PathVariable UUID userId) {
+        return assetSnapshotService.getTodaySnapshotsByUser(userId);
+    }
+
+    @GetMapping("/{userId}/{symbol}/history")
+    public List<SnapshotHistoryDto> getHistory(
+            @PathVariable UUID userId,
+            @PathVariable String symbol
+    ) {
+        return assetSnapshotService.getSnapshotHistoryBySymbol(userId, symbol);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/Asset.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/Asset.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Table(name = "asset",
         uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "symbol"}))
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/AssetPriceHistory.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/AssetPriceHistory.java
@@ -1,10 +1,13 @@
 package dev.asset_tracker_server.entity;
 
 import jakarta.persistence.*;
+import lombok.Setter;
+
 import java.util.UUID;
 import java.time.LocalDateTime;
 
 @Entity
+@Setter
 @Table(name = "asset_price_history")
 public class AssetPriceHistory {
     @Id

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/User.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/User.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "user")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetPriceHistoryRepository.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetPriceHistoryRepository.java
@@ -1,0 +1,15 @@
+package dev.asset_tracker_server.repository;
+
+import dev.asset_tracker_server.entity.AssetPriceHistory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AssetPriceHistoryRepository extends JpaRepository<AssetPriceHistory, UUID> {
+    List<AssetPriceHistory> findBySymbolOrderByTimestampDesc(String symbol, Pageable pageable);
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetSnapshotRepository.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetSnapshotRepository.java
@@ -1,8 +1,11 @@
 package dev.asset_tracker_server.repository;
 
+import dev.asset_tracker_server.api.dto.DailyAssetReportDto;
 import dev.asset_tracker_server.entity.AssetSnapshot;
 import dev.asset_tracker_server.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -20,4 +23,17 @@ public interface AssetSnapshotRepository extends JpaRepository<AssetSnapshot, UU
     List<AssetSnapshot> findByUserAndSymbolOrderBySnapshotDateAsc(User user, String symbol);
 
     Optional<AssetSnapshot> findByUserAndSymbolAndSnapshotDate(User user, String symbol, LocalDate snapshotDate);
+
+    @Query("""
+    SELECT new dev.asset_tracker_server.api.dto.DailyAssetReportDto(
+        a.snapshotDate,
+        SUM(a.totalValueKrw),
+        SUM(a.totalValueUsd)
+    )
+    FROM AssetSnapshot a
+    WHERE a.user.id = :userId AND a.snapshotDate >= :fromDate
+    GROUP BY a.snapshotDate
+    ORDER BY a.snapshotDate ASC
+""")
+    List<DailyAssetReportDto> findDailyReport(@Param("userId") UUID userId, @Param("fromDate") LocalDate fromDate);
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPriceHistoryService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPriceHistoryService.java
@@ -1,0 +1,56 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import dev.asset_tracker_server.entity.AssetPriceHistory;
+import dev.asset_tracker_server.entity.ExchangeRate;
+import dev.asset_tracker_server.repository.AssetPriceHistoryRepository;
+import dev.asset_tracker_server.repository.ExchangeRateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AssetPriceHistoryService {
+
+    private final AssetPriceHistoryRepository historyRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+
+    public void save(TickerPriceDto dto) {
+        String rateType = switch (dto.currency().toUpperCase()) {
+            case "USDT" -> "USDT/KRW";
+            case "USD" -> "USD/KRW";
+            default -> throw new IllegalArgumentException("지원하지 않는 통화: " + dto.currency());
+        };
+
+        ExchangeRate latestRate = exchangeRateRepository.findLatestByType(rateType, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("환율 정보 없음: " + rateType));
+
+        BigDecimal priceUsd = dto.price();
+        BigDecimal priceKrw = priceUsd.multiply(latestRate.getRate());
+
+        AssetPriceHistory history = new AssetPriceHistory();
+        history.setId(UUID.randomUUID());
+        history.setSymbol(dto.symbol());
+        history.setTimestamp(LocalDateTime.ofInstant(Instant.ofEpochMilli(dto.timestamp()), java.time.ZoneId.systemDefault()));
+        history.setPriceUsd(priceUsd.toPlainString());
+        history.setPriceKrw(priceKrw.toPlainString());
+
+        historyRepository.save(history);
+        log.info("📝 가격 히스토리 저장 완료: {} | {} USD ≒ {} KRW", dto.symbol(), priceUsd, priceKrw);
+    }
+
+    public List<AssetPriceHistory> getRecentHistory(String symbol, int limit) {
+        return historyRepository.findBySymbolOrderByTimestampDesc(symbol, PageRequest.of(0, limit));
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetService.java
@@ -1,0 +1,55 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.entity.Asset;
+import dev.asset_tracker_server.entity.User;
+import dev.asset_tracker_server.repository.AssetRepository;
+import dev.asset_tracker_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import dev.asset_tracker_server.entity.AssetType;
+
+@Service
+@RequiredArgsConstructor
+public class AssetService {
+
+    private final AssetRepository assetRepository;
+    private final UserRepository userRepository;
+
+    public static record AssetDto(String symbol, BigDecimal quantity, AssetType assetType, boolean isKimchi) {}
+
+    public List<AssetDto> getAssetsByUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        return assetRepository.findByUser(user).stream()
+                .map(asset -> new AssetDto(asset.getSymbol(), asset.getQuantity(), asset.getAssetType(), asset.isKimchi()))
+                .toList();
+    }
+
+    public void saveAsset(UUID userId, Asset asset) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        // 중복 심볼 방지
+        boolean exists = assetRepository.findByUser(user).stream()
+                .anyMatch(a -> a.getSymbol().equals(asset.getSymbol()));
+        if (exists) {
+            throw new IllegalArgumentException("이미 등록된 자산 심볼입니다.");
+        }
+        // 수량 음수 방지
+        if (asset.getQuantity() == null || asset.getQuantity().compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("자산 수량은 0 이상이어야 합니다.");
+        }
+        // 자산 유형 필수
+        if (asset.getAssetType() == null) {
+            throw new IllegalArgumentException("자산 유형은 필수입니다.");
+        }
+
+        asset.setUser(user);
+        assetRepository.save(asset);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetSnapshotService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetSnapshotService.java
@@ -1,5 +1,7 @@
 package dev.asset_tracker_server.service;
 
+import dev.asset_tracker_server.api.dto.SnapshotHistoryDto;
+import dev.asset_tracker_server.api.dto.SnapshotSummaryDto;
 import dev.asset_tracker_server.api.dto.TickerPriceDto;
 import dev.asset_tracker_server.entity.AssetSnapshot;
 import dev.asset_tracker_server.entity.ExchangeRate;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import dev.asset_tracker_server.entity.AssetType;
 import dev.asset_tracker_server.entity.User;
@@ -100,5 +103,34 @@ public class AssetSnapshotService {
         } else {
             saveRawSnapshot(dto);
         }
+    }
+
+    public List<SnapshotSummaryDto> getTodaySnapshotsByUser(UUID userId) {
+        User user = User.builder().id(userId).build();
+        LocalDate today = LocalDate.now();
+
+        return assetSnapshotRepository.findByUserAndSnapshotDate(user, today)
+                .stream()
+                .map(snapshot -> new SnapshotSummaryDto(
+                        snapshot.getSymbol(),
+                        snapshot.getAssetType(),
+                        snapshot.getTotalValueUsd(),
+                        snapshot.getTotalValueKrw(),
+                        snapshot.getSnapshotDate()
+                ))
+                .toList();
+    }
+
+    public List<SnapshotHistoryDto> getSnapshotHistoryBySymbol(UUID userId, String symbol) {
+        User user = User.builder().id(userId).build();
+
+        return assetSnapshotRepository.findByUserAndSymbolOrderBySnapshotDateAsc(user, symbol)
+                .stream()
+                .map(snapshot -> new SnapshotHistoryDto(
+                        snapshot.getTotalValueUsd(),
+                        snapshot.getTotalValueKrw(),
+                        snapshot.getSnapshotDate()
+                ))
+                .toList();
     }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetValuationService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetValuationService.java
@@ -1,0 +1,70 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.PortfolioValuationDto;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import dev.asset_tracker_server.entity.Asset;
+import dev.asset_tracker_server.entity.SymbolMapping;
+import dev.asset_tracker_server.entity.User;
+import dev.asset_tracker_server.fetcher.PriceFetchManager;
+import dev.asset_tracker_server.repository.AssetRepository;
+import dev.asset_tracker_server.repository.ExchangeRateRepository;
+import dev.asset_tracker_server.repository.SymbolMappingRepository;
+import dev.asset_tracker_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AssetValuationService {
+
+    private final UserRepository userRepository;
+    private final AssetRepository assetRepository;
+    private final SymbolMappingRepository symbolMappingRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final PriceFetchManager priceFetchManager;
+
+    public PortfolioValuationDto getPortfolioSummary(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        List<Asset> assets = assetRepository.findByUser(user);
+        BigDecimal totalUsd = BigDecimal.ZERO;
+        BigDecimal totalKrw = BigDecimal.ZERO;
+
+        for (Asset asset : assets) {
+            SymbolMapping mapping = symbolMappingRepository.findById(asset.getSymbol())
+                    .orElseThrow(() -> new IllegalArgumentException("심볼 매핑이 없습니다: " + asset.getSymbol()));
+
+            TickerPriceDto dto = priceFetchManager.fetch(mapping.getExchange().name(), mapping.getExchangeSymbol());
+            BigDecimal quantity = asset.getQuantity();
+            BigDecimal pricePerUnit = dto.price();
+            BigDecimal valueUsd = pricePerUnit.multiply(quantity);
+
+            BigDecimal rate = switch (dto.currency()) {
+                case "USDT" -> exchangeRateRepository.findLatestByType("USDT/KRW", PageRequest.of(0, 1)).get(0).getRate();
+                case "USD" -> exchangeRateRepository.findLatestByType("USD/KRW", PageRequest.of(0, 1)).get(0).getRate();
+                default -> BigDecimal.ONE;
+            };
+
+            BigDecimal valueKrw = valueUsd.multiply(rate);
+
+            totalUsd = totalUsd.add(valueUsd);
+            totalKrw = totalKrw.add(valueKrw);
+        }
+
+        return PortfolioValuationDto.builder()
+                .userId(userId)
+                .totalValueUsd(totalUsd)
+                .totalValueKrw(totalKrw)
+                .asOf(Instant.now())
+                .build();
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/ReportService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/ReportService.java
@@ -1,0 +1,25 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.DailyAssetReportDto;
+import dev.asset_tracker_server.repository.AssetSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final AssetSnapshotRepository assetSnapshotRepository;
+
+    // 시스템 계정 기준 일별 리포트 조회 (향후 로그인 사용자 기준으로 확장 가능)
+    private static final UUID SYSTEM_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+    public List<DailyAssetReportDto> getDailyReport(int days) {
+        LocalDate fromDate = LocalDate.now().minusDays(days);
+        return assetSnapshotRepository.findDailyReport(SYSTEM_USER_ID, fromDate);
+    }
+}


### PR DESCRIPTION
## PR 요약

유저 포트폴리오 조회, 자산 총합 계산 로직 구현

---

## 변경 사항

### 1. 유저 포트폴리오 자산 총합 계산
사용자의 전체 자산(포트폴리오) 총합을 계산

### 2. 자산 조회/등록 API 리팩토링
자산 조회 시 엔티티(Asset)를 직접 반환하지 않고, DTO(AssetDto)로 감싸서 반환하도록 개선

### 3. 자산 등록 시 검증 로직 추가
동일 심볼의 자산 중복 등록 방지
자산 수량이 0 이상인지 검증
자산 유형(AssetType) 필수값 검증

### 4. 가격 수집 스케쥴러 및 자산 스냅샷 저장
여러 거래소에서 주기적으로 가격을 수집하고, 자산 스냅샷을 저장