### PR TITLE
feat: 포트폴리오 총 평가액 계산 / 개별 자산 평가 구현

### DIFF
--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/AssetEvaluationDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/AssetEvaluationDto.java
@@ -1,0 +1,21 @@
+package dev.asset_tracker_server.api.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class AssetEvaluationDto {
+    private String symbol;
+    private BigDecimal quantity;
+
+    private BigDecimal unitPriceUsd;
+    private BigDecimal unitPriceKrw;
+
+    private BigDecimal totalValueUsd;
+    private BigDecimal totalValueKrw;
+
+    private String currency;   // USD or USDT or KRW
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioHistoryDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioHistoryDto.java
@@ -1,0 +1,10 @@
+package dev.asset_tracker_server.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PortfolioHistoryDto(
+        LocalDate date,
+        BigDecimal totalValueUsd,
+        BigDecimal totalValueKrw
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioSummaryDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/PortfolioSummaryDto.java
@@ -1,0 +1,8 @@
+package dev.asset_tracker_server.api.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioSummaryDto(
+        BigDecimal totalValueUsd,
+        BigDecimal totalValueKrw
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotChartDto.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/api/dto/SnapshotChartDto.java
@@ -1,0 +1,9 @@
+package dev.asset_tracker_server.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SnapshotChartDto(
+        LocalDate date,
+        BigDecimal value
+) {}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetChartController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetChartController.java
@@ -1,0 +1,31 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.SnapshotChartDto;
+import dev.asset_tracker_server.service.AssetChartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chart")
+public class AssetChartController {
+
+    private final AssetChartService assetChartService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<SnapshotChartDto>> getChartData(
+            @PathVariable UUID userId,
+            @RequestParam(defaultValue = "KRW") String currency
+    ) {
+        List<SnapshotChartDto> chartData = assetChartService.getDailySnapshots(userId, currency);
+        return ResponseEntity.ok(chartData);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetController.java
@@ -4,9 +4,11 @@ import dev.asset_tracker_server.entity.Asset;
 import dev.asset_tracker_server.service.AssetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +35,24 @@ public class AssetController {
     ) {
         assetService.saveAsset(userId, asset);
         return ResponseEntity.ok("자산 등록 완료");
+    }
+
+    @PutMapping("/{userId}/{assetId}")
+    public ResponseEntity<?> updateAsset(
+            @PathVariable UUID userId,
+            @PathVariable UUID assetId,
+            @RequestBody Asset updatedAsset
+    ) {
+        assetService.updateAsset(userId, assetId, updatedAsset);
+        return ResponseEntity.ok("자산 수정 완료");
+    }
+
+    @DeleteMapping("/{userId}/{assetId}")
+    public ResponseEntity<?> deleteAsset(
+            @PathVariable UUID userId,
+            @PathVariable UUID assetId
+    ) {
+        assetService.deleteAsset(userId, assetId);
+        return ResponseEntity.ok("자산 삭제 완료");
     }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetPortfolioController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetPortfolioController.java
@@ -1,0 +1,35 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.AssetEvaluationDto;
+import dev.asset_tracker_server.service.AssetPortfolioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/portfolio")
+public class AssetPortfolioController {
+
+    private final AssetPortfolioService assetPortfolioService;
+
+    @GetMapping("/{userId}/total")
+    public ResponseEntity<Map<String, BigDecimal>> getTotalValue(@PathVariable UUID userId) {
+        Map<String, BigDecimal> total = assetPortfolioService.calculatePortfolioValue(userId);
+        return ResponseEntity.ok(total);
+    }
+
+    @GetMapping("/{userId}/evaluate")
+    public ResponseEntity<List<AssetEvaluationDto>> getEvaluationDetails(@PathVariable UUID userId) {
+        List<AssetEvaluationDto> details = assetPortfolioService.evaluatePortfolio(userId);
+        return ResponseEntity.ok(details);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetSnapshotController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/AssetSnapshotController.java
@@ -1,0 +1,38 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.entity.AssetSnapshot;
+import dev.asset_tracker_server.service.AssetSnapshotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/snapshots")
+@RequiredArgsConstructor
+public class AssetSnapshotController {
+
+    private final AssetSnapshotService assetSnapshotService;
+
+    @GetMapping("/{userId}")
+    public List<AssetSnapshot> getAllSnapshots(@PathVariable UUID userId) {
+        return assetSnapshotService.getSnapshots(userId);
+    }
+
+    @GetMapping("/{userId}/date")
+    public ResponseEntity<List<AssetSnapshot>> getSnapshotsByDate(
+            @PathVariable UUID userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        List<AssetSnapshot> snapshots = assetSnapshotService.getSnapshotsByDate(userId, date);
+        return ResponseEntity.ok(snapshots);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/PortfolioController.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/controller/PortfolioController.java
@@ -1,0 +1,31 @@
+package dev.asset_tracker_server.controller;
+
+import dev.asset_tracker_server.api.dto.PortfolioHistoryDto;
+import dev.asset_tracker_server.api.dto.PortfolioSummaryDto;
+import dev.asset_tracker_server.service.AssetPortfolioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/portfolio")
+@RequiredArgsConstructor
+public class PortfolioController {
+
+    private final AssetPortfolioService assetPortfolioService;
+
+    @GetMapping("/{userId}/summary")
+    public PortfolioSummaryDto getSummary(@PathVariable UUID userId) {
+        return assetPortfolioService.getPortfolioSummary(userId);
+    }
+
+    @GetMapping("/{userId}/history")
+    public List<PortfolioHistoryDto> getHistory(@PathVariable UUID userId) {
+        return assetPortfolioService.getPortfolioHistory(userId);
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/Asset.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/entity/Asset.java
@@ -32,6 +32,10 @@ public class Asset extends BaseTimeEntity {
     @Column(length = 30, nullable = false)
     private String symbol;
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private Exchange exchange;
+
     @Column(precision = 20, scale = 8, nullable = false)
     private BigDecimal quantity;
 

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetSnapshotRepository.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/repository/AssetSnapshotRepository.java
@@ -36,4 +36,15 @@ public interface AssetSnapshotRepository extends JpaRepository<AssetSnapshot, UU
     ORDER BY a.snapshotDate ASC
 """)
     List<DailyAssetReportDto> findDailyReport(@Param("userId") UUID userId, @Param("fromDate") LocalDate fromDate);
+
+    @Query("""
+    SELECT s.snapshotDate AS date,
+           SUM(s.totalValueUsd) AS totalUsd,
+           SUM(s.totalValueKrw) AS totalKrw
+    FROM AssetSnapshot s
+    WHERE s.user = :user
+    GROUP BY s.snapshotDate
+    ORDER BY s.snapshotDate ASC
+""")
+    List<Object[]> findDailyPortfolioHistory(@Param("user") User user);
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetChartService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetChartService.java
@@ -1,0 +1,43 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.SnapshotChartDto;
+import dev.asset_tracker_server.entity.AssetSnapshot;
+import dev.asset_tracker_server.entity.User;
+import dev.asset_tracker_server.repository.AssetSnapshotRepository;
+import dev.asset_tracker_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AssetChartService {
+
+    private final AssetSnapshotRepository assetSnapshotRepository;
+    private final UserRepository userRepository;
+
+    public List<SnapshotChartDto> getDailySnapshots(UUID userId, String currency) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+
+        List<AssetSnapshot> snapshots = assetSnapshotRepository.findByUserOrderBySnapshotDateAsc(user);
+
+        // 날짜별로 그룹핑해서 합산
+        Map<LocalDate, BigDecimal> grouped = new TreeMap<>();
+
+        for (AssetSnapshot s : snapshots) {
+            BigDecimal value = "KRW".equalsIgnoreCase(currency) ? s.getTotalValueKrw() : s.getTotalValueUsd();
+            grouped.merge(s.getSnapshotDate(), value, BigDecimal::add);
+        }
+
+        return grouped.entrySet().stream()
+                .map(e -> new SnapshotChartDto(e.getKey(), e.getValue()))
+                .toList();
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPortfolioDetailService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPortfolioDetailService.java
@@ -1,0 +1,93 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.AssetEvaluationDto;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import dev.asset_tracker_server.entity.Asset;
+import dev.asset_tracker_server.entity.AssetType;
+import dev.asset_tracker_server.entity.ExchangeRate;
+import dev.asset_tracker_server.entity.User;
+import dev.asset_tracker_server.fetcher.PriceFetchManager;
+import dev.asset_tracker_server.repository.AssetRepository;
+import dev.asset_tracker_server.repository.ExchangeRateRepository;
+import dev.asset_tracker_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AssetPortfolioDetailService {
+
+    private final AssetRepository assetRepository;
+    private final UserRepository userRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final PriceFetchManager priceFetchManager;
+
+    public List<AssetEvaluationDto> getDetailedEvaluation(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다"));
+
+        List<Asset> assets = assetRepository.findByUser(user);
+
+        ExchangeRate usdRate = exchangeRateRepository.findLatestByType("USD/KRW", PageRequest.of(0, 1))
+                .stream().findFirst().orElseThrow();
+        ExchangeRate usdtRate = exchangeRateRepository.findLatestByType("USDT/KRW", PageRequest.of(0, 1))
+                .stream().findFirst().orElseThrow();
+
+        return assets.stream().map(asset -> {
+            BigDecimal unitPriceUsd = BigDecimal.ZERO;
+            BigDecimal unitPriceKrw = BigDecimal.ZERO;
+
+            String currency = "USD";
+
+            if (asset.getAssetType() == AssetType.CASH) {
+                // USD, KRW, USDT 현금형
+                switch (asset.getSymbol().toUpperCase()) {
+                    case "KRW" -> {
+                        unitPriceKrw = BigDecimal.ONE;
+                        unitPriceUsd = BigDecimal.ONE.divide(usdRate.getUsdToKrw(), 6, BigDecimal.ROUND_HALF_UP);
+                        currency = "KRW";
+                    }
+                    case "USD" -> {
+                        unitPriceUsd = BigDecimal.ONE;
+                        unitPriceKrw = usdRate.getUsdToKrw();
+                        currency = "USD";
+                    }
+                    case "USDT" -> {
+                        unitPriceUsd = BigDecimal.ONE;
+                        unitPriceKrw = usdtRate.getUsdtToKrw();
+                        currency = "USDT";
+                    }
+                }
+            } else {
+                // 실시간 가격 조회
+                String exchange = (asset.getAssetType() == AssetType.STOCK) ? "finnhub" : asset.getExchange().name().toLowerCase();
+                TickerPriceDto priceDto = priceFetchManager.fetch(exchange, asset.getSymbol());
+                unitPriceUsd = priceDto.price();
+                unitPriceKrw = priceDto.price().multiply(
+                        priceDto.currency().equalsIgnoreCase("USDT") ?
+                                usdtRate.getUsdtToKrw() : usdRate.getUsdToKrw());
+                currency = priceDto.currency();
+            }
+
+            BigDecimal totalUsd = unitPriceUsd.multiply(asset.getQuantity());
+            BigDecimal totalKrw = unitPriceKrw.multiply(asset.getQuantity());
+
+            return AssetEvaluationDto.builder()
+                    .symbol(asset.getSymbol())
+                    .quantity(asset.getQuantity())
+                    .unitPriceUsd(unitPriceUsd)
+                    .unitPriceKrw(unitPriceKrw)
+                    .totalValueUsd(totalUsd)
+                    .totalValueKrw(totalKrw)
+                    .currency(currency)
+                    .build();
+
+        }).collect(Collectors.toList());
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPortfolioService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetPortfolioService.java
@@ -1,0 +1,228 @@
+package dev.asset_tracker_server.service;
+
+import dev.asset_tracker_server.api.dto.AssetEvaluationDto;
+import dev.asset_tracker_server.api.dto.PortfolioHistoryDto;
+import dev.asset_tracker_server.api.dto.PortfolioSummaryDto;
+import dev.asset_tracker_server.api.dto.TickerPriceDto;
+import dev.asset_tracker_server.entity.Asset;
+import dev.asset_tracker_server.entity.AssetType;
+import dev.asset_tracker_server.entity.ExchangeRate;
+import dev.asset_tracker_server.entity.User;
+import dev.asset_tracker_server.entity.SymbolMapping;
+import dev.asset_tracker_server.fetcher.PriceFetchManager;
+import dev.asset_tracker_server.repository.AssetRepository;
+import dev.asset_tracker_server.repository.AssetSnapshotRepository;
+import dev.asset_tracker_server.repository.ExchangeRateRepository;
+import dev.asset_tracker_server.repository.SymbolMappingRepository;
+import dev.asset_tracker_server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AssetPortfolioService {
+
+    private final AssetRepository assetRepository;
+    private final PriceFetchManager priceFetchManager;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final SymbolMappingRepository symbolMappingRepository;
+    private final UserRepository userRepository;
+    private final AssetSnapshotRepository assetSnapshotRepository;
+
+    public Map<String, BigDecimal> calculatePortfolioValue(UUID userId) {
+        User user = User.builder().id(userId).build();
+        List<Asset> assets = assetRepository.findByUser(user);
+
+        BigDecimal totalUsd = BigDecimal.ZERO;
+        BigDecimal totalKrw = BigDecimal.ZERO;
+
+        // 최신 환율 정보
+        BigDecimal usdToKrw = getExchangeRate("USD/KRW");
+        BigDecimal usdtToKrw = getExchangeRate("USDT/KRW");
+
+        for (Asset asset : assets) {
+            SymbolMapping mapping = symbolMappingRepository.findById(asset.getSymbol())
+                    .orElseThrow(() -> new IllegalArgumentException("심볼 매핑 정보 없음"));
+            String exchange = asset.getAssetType() == AssetType.STOCK
+                    ? "finnhub"
+                    : mapping.getExchange().name().toLowerCase();
+            String symbol = asset.getSymbol();
+
+            try {
+                TickerPriceDto priceDto = priceFetchManager.fetch(exchange, symbol);
+                BigDecimal price = priceDto.price();
+                BigDecimal quantity = asset.getQuantity();
+                BigDecimal valueUsd = price.multiply(quantity);
+
+                totalUsd = totalUsd.add(valueUsd);
+
+                // 환산
+                BigDecimal rate = priceDto.currency().equals("USDT") ? usdtToKrw : usdToKrw;
+                totalKrw = totalKrw.add(valueUsd.multiply(rate));
+            } catch (Exception e) {
+                log.warn("가격 조회 실패: {} - {}", symbol, e.getMessage());
+            }
+        }
+
+        return Map.of(
+                "totalUsd", totalUsd,
+                "totalKrw", totalKrw
+        );
+    }
+
+    private BigDecimal getExchangeRate(String type) {
+        return exchangeRateRepository.findLatestByType(type, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .map(rate -> rate.getRate())
+                .orElseThrow(() -> new IllegalStateException("환율 정보 없음: " + type));
+    }
+
+    public PortfolioSummaryDto getPortfolioSummary(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        List<Asset> assets = assetRepository.findByUser(user);
+
+        BigDecimal totalUsd = BigDecimal.ZERO;
+        BigDecimal totalKrw = BigDecimal.ZERO;
+
+        for (Asset asset : assets) {
+            String symbol = asset.getSymbol();
+            BigDecimal quantity = asset.getQuantity();
+            AssetType type = asset.getAssetType();
+
+            // 심볼 정보 매핑
+            SymbolMapping mapping = symbolMappingRepository.findById(symbol)
+                    .orElseThrow(() -> new IllegalArgumentException("심볼 매핑 없음"));
+
+            // 가격 조회
+            TickerPriceDto priceDto = priceFetchManager.fetch(mapping.getExchange().name(), mapping.getExchangeSymbol());
+            BigDecimal price = priceDto.price();
+            String currency = priceDto.currency();
+
+            BigDecimal assetValue = price.multiply(quantity);
+            totalUsd = totalUsd.add(assetValue);
+
+            // 환율 조회
+            String rateType = switch (currency) {
+                case "USD" -> "USD/KRW";
+                case "USDT" -> "USDT/KRW";
+                case "KRW" -> null; // KRW라면 변환 불필요
+                default -> throw new RuntimeException("지원하지 않는 통화: " + currency);
+            };
+
+            BigDecimal valueKrw;
+            if (rateType != null) {
+                ExchangeRate rate = exchangeRateRepository.findLatestByType(rateType, PageRequest.of(0, 1))
+                        .stream().findFirst()
+                        .orElseThrow(() -> new RuntimeException("환율 정보 없음"));
+                valueKrw = assetValue.multiply(rate.getRate());
+            } else {
+                valueKrw = assetValue;
+            }
+
+            totalKrw = totalKrw.add(valueKrw);
+        }
+
+        return new PortfolioSummaryDto(totalUsd, totalKrw);
+    }
+
+    public List<PortfolioHistoryDto> getPortfolioHistory(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        List<Object[]> result = assetSnapshotRepository.findDailyPortfolioHistory(user);
+
+        return result.stream()
+                .map(row -> new PortfolioHistoryDto(
+                        (LocalDate) row[0],
+                        (BigDecimal) row[1],
+                        (BigDecimal) row[2]
+                ))
+                .toList();
+    }
+
+    public List<AssetEvaluationDto> evaluatePortfolio(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+        List<Asset> assets = assetRepository.findByUser(user);
+
+        // 최신 환율 정보 조회
+        BigDecimal usdToKrw = exchangeRateRepository.findLatestByType("USD/KRW", PageRequest.of(0, 1))
+                .stream().findFirst().orElseThrow(() -> new RuntimeException("환율 정보 없음")).getUsdToKrw();
+
+        BigDecimal usdtToKrw = exchangeRateRepository.findLatestByType("USDT/KRW", PageRequest.of(0, 1))
+                .stream().findFirst().orElseThrow(() -> new RuntimeException("환율 정보 없음")).getUsdtToKrw();
+
+        List<AssetEvaluationDto> results = new ArrayList<>();
+
+        for (Asset asset : assets) {
+            BigDecimal quantity = asset.getQuantity();
+            String symbol = asset.getSymbol();
+            // 거래소명 결정
+            String exchange;
+            if (asset.getAssetType() == AssetType.STOCK) {
+                exchange = "finnhub";
+            } else {
+                SymbolMapping mapping = symbolMappingRepository.findById(symbol)
+                        .orElseThrow(() -> new IllegalArgumentException("심볼 매핑 정보 없음"));
+                exchange = mapping.getExchange().name().toLowerCase();
+            }
+
+            BigDecimal priceUsd;
+            BigDecimal priceKrw;
+
+            // 가격 조회
+            if (asset.getAssetType() == AssetType.CASH) {
+                if (symbol.equalsIgnoreCase("KRW")) {
+                    priceUsd = usdToKrw.divide(usdToKrw, 2, RoundingMode.HALF_UP);
+                    priceKrw = BigDecimal.ONE;
+                } else if (symbol.equalsIgnoreCase("USD")) {
+                    priceUsd = BigDecimal.ONE;
+                    priceKrw = usdToKrw;
+                } else if (symbol.equalsIgnoreCase("USDT")) {
+                    priceUsd = BigDecimal.ONE;
+                    priceKrw = usdtToKrw;
+                } else {
+                    continue;
+                }
+            } else {
+                var dto = priceFetchManager.fetch(exchange, symbol);
+                priceUsd = dto.price();
+                priceKrw = switch (dto.currency()) {
+                    case "USDT" -> priceUsd.multiply(usdtToKrw);
+                    case "USD" -> priceUsd.multiply(usdToKrw);
+                    case "KRW" -> priceUsd;
+                    default -> throw new IllegalArgumentException("지원하지 않는 통화: " + dto.currency());
+                };
+            }
+
+            BigDecimal totalUsd = priceUsd.multiply(quantity);
+            BigDecimal totalKrw = priceKrw.multiply(quantity);
+
+            results.add(AssetEvaluationDto.builder()
+                    .symbol(symbol)
+                    .quantity(quantity)
+                    .unitPriceUsd(priceUsd)
+                    .unitPriceKrw(priceKrw)
+                    .totalValueUsd(totalUsd)
+                    .totalValueKrw(totalKrw)
+                    .currency(exchange)
+                    .build());
+        }
+
+        return results;
+    }
+}

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetService.java
@@ -52,4 +52,36 @@ public class AssetService {
         asset.setUser(user);
         assetRepository.save(asset);
     }
+
+    public void updateAsset(UUID userId, UUID assetId, Asset updatedAsset) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        Asset existing = assetRepository.findById(assetId)
+                .orElseThrow(() -> new IllegalArgumentException("자산 없음"));
+
+        if (!existing.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("해당 자산은 사용자의 소유가 아닙니다");
+        }
+
+        // 필요한 필드만 업데이트 (여기서는 심볼과 수량만 예시로)
+        existing.setSymbol(updatedAsset.getSymbol());
+        existing.setQuantity(updatedAsset.getQuantity());
+        existing.setAssetType(updatedAsset.getAssetType());
+        assetRepository.save(existing);
+    }
+
+    public void deleteAsset(UUID userId, UUID assetId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        Asset existing = assetRepository.findById(assetId)
+                .orElseThrow(() -> new IllegalArgumentException("자산 없음"));
+
+        if (!existing.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("해당 자산은 사용자의 소유가 아닙니다");
+        }
+
+        assetRepository.delete(existing);
+    }
 }

--- a/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetSnapshotService.java
+++ b/asset-tracker-server/src/main/java/dev/asset_tracker_server/service/AssetSnapshotService.java
@@ -7,6 +7,7 @@ import dev.asset_tracker_server.entity.AssetSnapshot;
 import dev.asset_tracker_server.entity.ExchangeRate;
 import dev.asset_tracker_server.repository.AssetSnapshotRepository;
 import dev.asset_tracker_server.repository.ExchangeRateRepository;
+import dev.asset_tracker_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -26,6 +27,7 @@ public class AssetSnapshotService {
 
     private final AssetSnapshotRepository assetSnapshotRepository;
     private final ExchangeRateRepository exchangeRateRepository;
+    private final UserRepository userRepository;
 
     // 시스템 계정 UUID (개발용, 실무에서는 별도 계정 관리 권장)
     private static final UUID SYSTEM_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
@@ -132,5 +134,17 @@ public class AssetSnapshotService {
                         snapshot.getSnapshotDate()
                 ))
                 .toList();
+    }
+
+    public List<AssetSnapshot> getSnapshots(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+        return assetSnapshotRepository.findByUserOrderBySnapshotDateAsc(user);
+    }
+
+    public List<AssetSnapshot> getSnapshotsByDate(UUID userId, LocalDate date) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+        return assetSnapshotRepository.findByUserAndSnapshotDate(user, date);
     }
 }


### PR DESCRIPTION
## PR 요약
- 포트폴리오 총 평가액 계산 기능 추가
- 개별 자산 평가 기능 추가

---

## 변경 사항
1. 거래소, 심볼 정보를 기반으로 사용자의 자산 실시간 가격 조희
2. 환율 (USD/KRW, USDT/KRW)을 적용하여 원화 가치 계산
3. 각 자산에 대한 수량, 가격 정보와 자산 총 평가액 계산
